### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/libin96/05edf39f-2b6f-426f-827f-d75c55eb7cd8/f6f20259-144d-482b-8d73-45fb20a3576e/_apis/work/boardbadge/59385342-6119-46cf-8104-792ec6c080fb)](https://dev.azure.com/libin96/05edf39f-2b6f-426f-827f-d75c55eb7cd8/_boards/board/t/f6f20259-144d-482b-8d73-45fb20a3576e/Microsoft.RequirementCategory)
 # SmartBlog
 This is my first blog.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/libin96/05edf39f-2b6f-426f-827f-d75c55eb7cd8/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.